### PR TITLE
--version フラグで version/commit/date を表示する

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,18 @@ import (
 	"github.com/yteraoka/sbottui/internal/tui"
 )
 
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
+	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "-v") {
+		fmt.Printf("version: %s\ncommit:  %s\ndate:    %s\n", version, commit, date)
+		return
+	}
+
 	token := os.Getenv("SWITCHBOT_TOKEN")
 	secret := os.Getenv("SWITCHBOT_CLIENT_SECRET")
 


### PR DESCRIPTION
## Summary

- `main.go` にパッケージレベル変数 `version`/`commit`/`date` を追加（デフォルト: `dev`/`none`/`unknown`）
- `--version` または `-v` 引数で version、commit hash、build 日時を表示して終了する機能を追加
- goreleaser ビルド時は既存の ldflags (`-X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}`) により git tag 等が自動で埋め込まれる

## Test plan

- [ ] `go build -ldflags "-X main.version=vX.Y.Z -X main.commit=abc1234 -X main.date=..." && ./sbottui --version` で正しく表示されることを確認
- [ ] `./sbottui -v` でも同様に表示されることを確認
- [ ] goreleaser でビルドしたバイナリで git tag が version に反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)