### PR TITLE
feat: require 7-day minimum release age before Renovate creates PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "groupName": "charmbracelet",


### PR DESCRIPTION
## Summary
- `minimumReleaseAge: "7 days"` を renovate.json に追加
- リリースから7日経過したパッケージのみ PR が作成されるようになる

🤖 Generated with [Claude Code](https://claude.com/claude-code)