### PR TITLE
Rename Homebrew tap repository to homebrew-cask

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: |
             sbottui
-            homebrew-tap
+            homebrew-cask
 
       - name: Run GoReleaser release (Tag Push)
         if: startsWith(github.ref, 'refs/tags/')

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,7 +48,7 @@ changelog:
 homebrew_casks:
   - repository:
       owner: yteraoka
-      name: homebrew-tap
+      name: homebrew-cask
       token: "{{ .Env.GITHUB_TOKEN }}"
       pull_request:
         enabled: false


### PR DESCRIPTION
## Summary
- Update the GitHub App token repository list and GoReleaser homebrew_casks target from `homebrew-tap` to `homebrew-cask`

🤖 Generated with [Claude Code](https://claude.com/claude-code)